### PR TITLE
Rewrite healthchecks to my personal style :)

### DIFF
--- a/src/presentation/http/routes/healthcheck/index.ts
+++ b/src/presentation/http/routes/healthcheck/index.ts
@@ -1,24 +1,24 @@
-import { pipe } from "fp-ts/function";
-import * as RT from "fp-ts/ReaderTask";
-import * as R from "fp-ts/Record";
-import * as S from "fp-ts/string";
-import * as T from "fp-ts/Task";
-import { z } from "zod";
+import { pipe } from 'fp-ts/function';
+import * as RT from 'fp-ts/ReaderTask';
+import * as R from 'fp-ts/Record';
+import * as S from 'fp-ts/string';
+import * as T from 'fp-ts/Task';
+import { z } from 'zod';
 import {
   getHealthcheck,
   GetHealthcheckResult,
-} from "../../../../application/healthcheck/get-healthcheck";
-import type { Cache } from "../../../../infrastructure/cache";
-import type { Database } from "../../../../infrastructure/database";
-import type { HttpServer } from "../../../../infrastructure/http";
-import { getHealthcheckRepository } from "../../../../repository/healthcheck";
+} from '../../../../application/healthcheck/get-healthcheck';
+import type { Cache } from '../../../../infrastructure/cache';
+import type { Database } from '../../../../infrastructure/database';
+import type { HttpServer } from '../../../../infrastructure/http';
+import { getHealthcheckRepository } from '../../../../repository/healthcheck';
 
 const healthcheckResponseSchema = z.object({
-  http: z.literal("healthy"),
-  database: z.union([z.literal("healthy"), z.literal("unhealthy")]),
-  cache: z.union([z.literal("healthy"), z.literal("unhealthy")]),
-  systemMemory: z.union([z.literal("healthy"), z.literal("unhealthy")]),
-  processMemory: z.union([z.literal("healthy"), z.literal("unhealthy")]),
+  http: z.literal('healthy'),
+  database: z.union([z.literal('healthy'), z.literal('unhealthy')]),
+  cache: z.union([z.literal('healthy'), z.literal('unhealthy')]),
+  systemMemory: z.union([z.literal('healthy'), z.literal('unhealthy')]),
+  processMemory: z.union([z.literal('healthy'), z.literal('unhealthy')]),
 });
 
 export type HealthcheckResponseSchema = z.infer<
@@ -39,10 +39,10 @@ export const bindHealthcheckRoutes = (): RT.ReaderTask<
     RT.ask<Dependencies>(),
     RT.map(({ httpServer, database, cache }) =>
       httpServer.createRoute({
-        method: "GET",
-        url: "/healthcheck",
+        method: 'GET',
+        url: '/healthcheck',
         schema: {
-          description: "Check the status of the application",
+          description: 'Check the status of the application',
           response: {
             200: healthcheckResponseSchema,
             500: healthcheckResponseSchema,
@@ -51,7 +51,7 @@ export const bindHealthcheckRoutes = (): RT.ReaderTask<
         handler: () =>
           pipe(
             { database, cache },
-            getHealthcheckRepository(),
+            getHealthcheckRepository,
             (repository) => ({
               repository,
               cache,
@@ -61,7 +61,7 @@ export const bindHealthcheckRoutes = (): RT.ReaderTask<
               status: computeStatus(healthcheckResult),
               body: {
                 ...healthcheckResult,
-                http: "healthy",
+                http: 'healthy',
               },
             }))
           ),
@@ -74,7 +74,7 @@ export function computeStatus(healthcheckResult: GetHealthcheckResult): number {
     { ...healthcheckResult },
     // eslint-disable-next-line unicorn/no-array-reduce, unicorn/no-array-callback-reference
     R.reduce(S.Ord)(200, (accumulator, statusEntry) =>
-      statusEntry !== "healthy" || accumulator === 500 ? 500 : accumulator
+      statusEntry !== 'healthy' || accumulator === 500 ? 500 : accumulator
     )
   );
 }

--- a/src/repository/healthcheck/get-healthcheck.ts
+++ b/src/repository/healthcheck/get-healthcheck.ts
@@ -1,37 +1,27 @@
-import { pipe } from "fp-ts/function";
-import * as RT from "fp-ts/ReaderTask";
-import * as T from "fp-ts/Task";
-import * as TE from "fp-ts/TaskEither";
-import { sql } from "slonik";
-import type {
-  Database,
-  DatabasePoolConnection,
-} from "../../infrastructure/database";
+import { pipe } from 'fp-ts/function';
+import * as RT from 'fp-ts/ReaderTask';
+import * as T from 'fp-ts/Task';
+import * as TE from 'fp-ts/TaskEither';
+import { sql } from 'slonik';
+import type { Database } from '../../infrastructure/database';
 
 interface Dependencies {
   readonly database: Database;
 }
 
 export type GetHealthcheckResult =
-  | { readonly outcome: "healthy" }
-  | { readonly outcome: "unhealthy" };
+  | { readonly outcome: 'healthy' }
+  | { readonly outcome: 'unhealthy' };
 
-export const getHealthcheck = (): RT.ReaderTask<
-  Dependencies,
-  GetHealthcheckResult
-> =>
-  pipe(
-    RT.ask<Dependencies>(),
-    RT.chain(({ database }) =>
-      RT.fromTask(
-        pipe(
-          (pool: DatabasePoolConnection) => pool.query(sql`select 1`),
-          database.runInConnection,
-          TE.fold<Error, unknown, GetHealthcheckResult>(
-            () => T.of({ outcome: "unhealthy" }),
-            () => T.of({ outcome: "healthy" })
-          )
-        )
+export const getHealthcheck = pipe(
+  RT.ask<Dependencies>(),
+  RT.chainTaskK(({ database }) =>
+    pipe(
+      database.runInConnection((pool) => pool.query(sql`select 1`)),
+      TE.fold<Error, unknown, GetHealthcheckResult>(
+        () => T.of({ outcome: 'unhealthy' }),
+        () => T.of({ outcome: 'healthy' })
       )
     )
-  );
+  )
+);

--- a/src/repository/healthcheck/index.ts
+++ b/src/repository/healthcheck/index.ts
@@ -1,24 +1,21 @@
-import { pipe } from "fp-ts/function";
-import * as R from "fp-ts/Reader";
-import * as T from "fp-ts/Task";
-import type { Database } from "../../infrastructure/database";
-import { getHealthcheck, GetHealthcheckResult } from "./get-healthcheck";
+import { pipe } from 'fp-ts/function';
+import * as R from 'fp-ts/Reader';
+import * as T from 'fp-ts/Task';
+import type { Database } from '../../infrastructure/database';
+import { getHealthcheck, GetHealthcheckResult } from './get-healthcheck';
 
 interface Dependencies {
   readonly database: Database;
 }
 
 export interface HealthcheckRepository {
-  readonly getHealthcheck: () => T.Task<GetHealthcheckResult>;
+  readonly getHealthcheck: T.Task<GetHealthcheckResult>;
 }
 
-export const getHealthcheckRepository = (): R.Reader<
+export const getHealthcheckRepository: R.Reader<
   Dependencies,
   HealthcheckRepository
-> =>
-  pipe(
-    R.ask<Dependencies>(),
-    R.map(({ database }) => ({
-      getHealthcheck: () => getHealthcheck()({ database }),
-    }))
-  );
+> = pipe(
+  R.Do,
+  R.bindW('getHealthcheck', () => getHealthcheck)
+);


### PR DESCRIPTION
## Description of the changes
Just as a point of information! My ambitions here are:
- Lean on type inference heavily to reduce visual noise and refactor
  effort
- Avoid re-packaging reader dependencies so that their types can be
  again refactored with relatively local scope (it would be annoying to
have to change the repository just because the typedef has changed, for
example).
- Don't wrap readers/tasks with thunks


-
-
-
